### PR TITLE
PHPCS-38: fluent setter. Added additional tests

### DIFF
--- a/src/Standards/BestIt/Sniffs/Functions/FluentSetterSniff.php
+++ b/src/Standards/BestIt/Sniffs/Functions/FluentSetterSniff.php
@@ -84,11 +84,6 @@ class FluentSetterSniff extends PHP_CodeSniffer_Standards_AbstractScopeSniff
         $className = $phpcsFile->getDeclarationName($currScope);
         $methodName = $phpcsFile->getDeclarationName($stackPtr);
 
-        //Ignore closure functions
-        if ($methodName === null) {
-            return;
-        }
-
         if (!$this->checkIfSetterFunction($methodName)) {
             return;
         }

--- a/tests/Standards/BestIt/Sniffs/Functions/Fixtures/FluentSetterSniff.Correct.php
+++ b/tests/Standards/BestIt/Sniffs/Functions/Fixtures/FluentSetterSniff.Correct.php
@@ -4,6 +4,10 @@ class FluentSetterSniff
 {
     private $test;
 
+    public function setupDatabase()
+    {
+    }
+
     public function setTest($test)
     {
         $this->test = $test;


### PR DESCRIPTION
Removed check for closure functions as they are not considered due to constructor-call.
Added additional tests to reach 100% coverage.