### PR TITLE
PHPCS-53: Use single quotes

### DIFF
--- a/src/Standards/BestIt/ruleset.xml
+++ b/src/Standards/BestIt/ruleset.xml
@@ -16,6 +16,6 @@
     </rule>
     <rule ref="Generic.Formatting.SpaceAfterCast" />
 
-    <rule ref="Squiz.Strings.DoubleQuoteUsage" />
+    <rule ref="Squiz.Strings.DoubleQuoteUsage.NotRequired" />
 
 </ruleset>


### PR DESCRIPTION
The current rule does not alloe variable interpolation. After this change, following rules are matching:

```
        // Valid
        $foo = 'Hello world';
        $opt1 = "Concat $foo";
        $opt3 = "My \n text";

        // Invalid
        $bar = "Hello world";
        $opt2 = "Concat " . $foo;
```