### PR TITLE
PHPCS-32 Inserted the missing sniff for the type hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ erroneous sibling.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
+### Semantic Versioning
+
+We use [semantic versioning](https://semver.org) in correlation with the style enforced by our ruleset and not directly 
+with our source code. This means, that there could be breaking change in our code, but as long as the style is not changed 
+heavily, then the breaking change will not be mirrored in our version number:
+
+- Patch-Version (last number): backwards-compatible bugfixes in our ruleset or source-code
+- Minor-Version (middle number): backwards-compatible features in our ruleset
+- Major-Version (first number): breaking change in our ruleset
+
 ## TODO 
 
 * Remove further slevomat dependencies for internal apis.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -10,6 +10,8 @@
     <exclude-pattern>*/Fixtures/*.php</exclude-pattern>
 
     <!-- So many copies of the original code from the sniffer/slevomat. Ignore it! -->
+    <exclude-pattern>./src/Standards/BestIt/CodeSniffer/AbstractFileDecorator.php</exclude-pattern>
+    <exclude-pattern>./src/Standards/BestIt/CodeSniffer/File.php</exclude-pattern>
     <exclude-pattern>*/AbstractFileDecorator.php</exclude-pattern>
     <exclude-pattern>*/SniffTestCase.php</exclude-pattern>
 </ruleset>

--- a/src/Standards/BestIt/CodeSniffer/Helper/DocHelper.php
+++ b/src/Standards/BestIt/CodeSniffer/Helper/DocHelper.php
@@ -53,7 +53,7 @@ class DocHelper
      * @param File $file File object of file which is processed.
      * @param int $stackPos Position to the token which is processed.
      */
-    public function __construct(File $file, $stackPos)
+    public function __construct(File $file, int $stackPos)
     {
         $this->file = $file;
         $this->tokens = $file->getTokens();

--- a/src/Standards/BestIt/Sniffs/AbstractSniff.php
+++ b/src/Standards/BestIt/Sniffs/AbstractSniff.php
@@ -105,6 +105,8 @@ abstract class AbstractSniff implements Sniff
     /**
      * Called when one of the token types that this sniff is listening for is found.
      *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     *
      * @param BaseFile $phpcsFile The PHP_CodeSniffer file where the token was found.
      * @param int $stackPos The position in the PHP_CodeSniffer file's token stack where the token was found.
      *

--- a/src/Standards/BestIt/Sniffs/Formatting/OpenTagSniff.php
+++ b/src/Standards/BestIt/Sniffs/Formatting/OpenTagSniff.php
@@ -72,6 +72,8 @@ class OpenTagSniff implements Sniff
     /**
      * Called when one of the token types that this sniff is listening for is found.
      *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     *
      * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
      * @param int $stackPtr The position in the PHP_CodeSniffer file's token stack where the token was found.
      *

--- a/src/Standards/BestIt/Sniffs/Formatting/SpaceAfterDeclareSniff.php
+++ b/src/Standards/BestIt/Sniffs/Formatting/SpaceAfterDeclareSniff.php
@@ -72,6 +72,8 @@ class SpaceAfterDeclareSniff implements Sniff
     /**
      * Called when one of the token types that this sniff is listening for is found.
      *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     *
      * @param File $phpcsFile The PHP_CodeSniffer file where the token was found.
      * @param int $stackPtr The position in the PHP_CodeSniffer file's token stack where the token was found.
      *

--- a/src/Standards/BestIt/Sniffs/Functions/FluentSetterSniff.php
+++ b/src/Standards/BestIt/Sniffs/Functions/FluentSetterSniff.php
@@ -153,6 +153,8 @@ class FluentSetterSniff extends MethodScopeSniff
     /**
      * Processes the tokens that this test is listening for.
      *
+     * @phpcsSuppress SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint
+     *
      * @param File $file The file where this token was found.
      * @param int $functionPos The position in the stack where this token was found.
      * @param int $classPos The position in the tokens array that opened the scope that this test is listening for.
@@ -233,7 +235,7 @@ class FluentSetterSniff extends MethodScopeSniff
      *
      * @return void
      */
-    private function fixMustReturnThis(File $phpcsFile, $returnPtr): void
+    private function fixMustReturnThis(File $phpcsFile, int $returnPtr): void
     {
         $returnSemicolonPtr = $phpcsFile->findEndOfStatement($returnPtr);
 

--- a/src/Standards/BestIt/ruleset.xml
+++ b/src/Standards/BestIt/ruleset.xml
@@ -53,6 +53,13 @@
         </properties>
     </rule>
 
+    <rule ref="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.MissingParameterTypeHint">
+        <properties>
+            <property name="allAnnotationsAreUseful" value="true"/>
+            <property name="enableEachParameterAndReturnInspection" value="true"/>
+        </properties>
+    </rule>
+
     <rule ref="Generic.Arrays.DisallowLongArraySyntax" />
 
     <rule ref="Generic.Formatting.SpaceAfterCast" />

--- a/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/correct/Correct.php
+++ b/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/correct/Correct.php
@@ -19,6 +19,16 @@ class TypeHintDeclarationSniff
     }
 
     /**
+     * Returns a file object.
+     *
+     * @return File
+     */
+    public function testCustomObject(): File
+    {
+        return new File();
+    }
+
+    /**
      * @phpcsSuppress BestIt.TypeHints.ReturnTypeDeclaration.MissingReturnTypeHint
      * @return int
      */

--- a/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5,15.fixed.php
+++ b/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5,15.fixed.php
@@ -1,0 +1,19 @@
+<?php
+
+class TypeHintDeclarationSniff
+{
+    public function testMethodWithoutDoc()
+    {
+        return false;
+    }
+
+    /**
+     * Returns a file object.
+     *
+     * @return File
+     */
+    public function testCustomObject()
+    {
+        return new File();
+    }
+}

--- a/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5,15.php
+++ b/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5,15.php
@@ -1,0 +1,19 @@
+<?php
+
+class TypeHintDeclarationSniff
+{
+    public function testMethodWithoutDoc()
+    {
+        return false;
+    }
+
+    /**
+     * Returns a file object.
+     *
+     * @return File
+     */
+    public function testCustomObject()
+    {
+        return new File();
+    }
+}

--- a/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5.fixed.php
+++ b/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5.fixed.php
@@ -1,9 +1,0 @@
-<?php
-
-class TypeHintDeclarationSniff
-{
-    public function testMethodWithoutDoc()
-    {
-        return false;
-    }
-}

--- a/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5.php
+++ b/tests/Sniffs/TypeHints/Fixtures/ReturnTypeDeclarationSniff/with_errors/MissingReturnTypeHint(unfixable).5.php
@@ -1,9 +1,0 @@
-<?php
-
-class TypeHintDeclarationSniff
-{
-    public function testMethodWithoutDoc()
-    {
-        return false;
-    }
-}


### PR DESCRIPTION
PHPCS-32 Added a documentation paragraph for the semantic versioning
PHPCS-32 Added checks for custom class return types to fully test the return type sniff