### PR TITLE
Pin down to compatible coding-standard dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     "prefer-stable": true,
     "require": {
         "php": ">=8.0",
-        "slevomat/coding-standard": "^8.0"
+        "slevomat/coding-standard": "8.0.*"
     },
     "require-dev": {
         "phpmd/phpmd": "^2.6",


### PR DESCRIPTION
Fixes errors occuring due to changed interfaces in recent slevomat/coding-standard ^8.0 releases.